### PR TITLE
Ensure radar station selection is saved correctly

### DIFF
--- a/contents/ui/configGeneral.qml
+++ b/contents/ui/configGeneral.qml
@@ -190,7 +190,7 @@ KCM.SimpleKCM {
             textRole: "display"
             valueRole: "code"
 
-            onActivated: {
+            onCurrentValueChanged: {
                 cfg_radarStation = currentValue
                 gifUrlField.text = "https://radar.weather.gov/ridge/standard/" + currentValue + "_loop.gif"
             }

--- a/contents/ui/configGeneral.qml
+++ b/contents/ui/configGeneral.qml
@@ -8,7 +8,9 @@ import org.kde.kcmutils as KCM
 KCM.SimpleKCM {
     property alias cfg_gifUrl: gifUrlField.text
     property alias cfg_refreshInterval: refreshIntervalSpinBox.value
-    property alias cfg_radarStation: radarStationCombo.currentValue
+    // Store selected radar station code. Cannot alias to ComboBox.currentValue
+    // because it is read-only.
+    property string cfg_radarStation
 
     ListModel {
         id: radarStationsModel
@@ -189,6 +191,7 @@ KCM.SimpleKCM {
             valueRole: "code"
 
             onActivated: {
+                cfg_radarStation = currentValue
                 gifUrlField.text = "https://radar.weather.gov/ridge/standard/" + currentValue + "_loop.gif"
             }
 


### PR DESCRIPTION
## Summary
- Store the radar station code in a dedicated property instead of aliasing to read-only `ComboBox.currentValue`
- Update the configuration property when the user selects a new station

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6897b0218114832a9b0b58c8c0e6d57c