### PR TITLE
Use FormLayout as configuration root

### DIFF
--- a/contents/ui/configGeneral.qml
+++ b/contents/ui/configGeneral.qml
@@ -3,19 +3,24 @@ import QtQuick
 import QtQuick.Controls as QQC2
 import QtQuick.Layouts
 import org.kde.kirigami as Kirigami
-import org.kde.kcmutils as KCM
-
-KCM.SimpleKCM {
+Kirigami.FormLayout {
+    // KConfig sets this property when loading the page
+    property string title
     property alias cfg_gifUrl: gifUrlField.text
     property alias cfg_refreshInterval: refreshIntervalSpinBox.value
     // Store selected radar station code. Cannot alias to ComboBox.currentValue
     // because it is read-only.
     property string cfg_radarStation
 
+    // default values injected by the KConfig loader
+    property string cfg_gifUrlDefault
+    property string cfg_radarStationDefault
+    property int cfg_refreshIntervalDefault
+
     ListModel {
         id: radarStationsModel
 
-        ListElement { stationCode: ""; stationName: i18n("Central Region"); active: false }
+        ListElement { stationCode: ""; stationName: "Central Region"; active: false }
         ListElement { stationCode: "KABR"; stationName: "Aberdeen, SD" }
         ListElement { stationCode: "KBIS"; stationName: "Bismarck, ND" }
         ListElement { stationCode: "KFTG"; stationName: "Denver/Boulder, CO" }
@@ -54,7 +59,7 @@ KCM.SimpleKCM {
         ListElement { stationCode: "KFSD"; stationName: "Sioux Falls, SD" }
         ListElement { stationCode: "KTWX"; stationName: "Topeka, KS" }
         ListElement { stationCode: "KICT"; stationName: "Wichita, KS" }
-        ListElement { stationCode: ""; stationName: i18n("Eastern Region"); active: false }
+        ListElement { stationCode: ""; stationName: "Eastern Region"; active: false }
         ListElement { stationCode: "KVWX"; stationName: "Evansville, IN" }
         ListElement { stationCode: "KLTX"; stationName: "Wilmington, NC" }
         ListElement { stationCode: "KCCX"; stationName: "State College, PA" }
@@ -79,7 +84,7 @@ KCM.SimpleKCM {
         ListElement { stationCode: "KOKX"; stationName: "New York City, NY" }
         ListElement { stationCode: "KCLX"; stationName: "Charleston, SC" }
         ListElement { stationCode: "KRLX"; stationName: "Charleston, WV" }
-        ListElement { stationCode: ""; stationName: i18n("Southern Region"); active: false }
+        ListElement { stationCode: ""; stationName: "Southern Region"; active: false }
         ListElement { stationCode: "KBRO"; stationName: "Brownsville, TX" }
         ListElement { stationCode: "KABX"; stationName: "Albuquerque, NM" }
         ListElement { stationCode: "KAMA"; stationName: "Amarillo, TX" }
@@ -112,7 +117,7 @@ KCM.SimpleKCM {
         ListElement { stationCode: "KDGX"; stationName: "Jackson, MS" }
         ListElement { stationCode: "KSHV"; stationName: "Shreveport, LA" }
         ListElement { stationCode: "KHDC"; stationName: "New Orleans, LA" }
-        ListElement { stationCode: ""; stationName: i18n("Western Region"); active: false }
+        ListElement { stationCode: ""; stationName: "Western Region"; active: false }
         ListElement { stationCode: "KLGX"; stationName: "Seattle, WA" }
         ListElement { stationCode: "KYUX"; stationName: "Yuma, AZ" }
         ListElement { stationCode: "KEMX"; stationName: "Tucson, AZ" }
@@ -141,7 +146,7 @@ KCM.SimpleKCM {
         ListElement { stationCode: "KCBX"; stationName: "Boise, ID" }
         ListElement { stationCode: "KBLX"; stationName: "Billings, MT" }
         ListElement { stationCode: "KICX"; stationName: "Cedar City, UT" }
-        ListElement { stationCode: ""; stationName: i18n("Pacific Region"); active: false }
+        ListElement { stationCode: ""; stationName: "Pacific Region"; active: false }
         ListElement { stationCode: "PABC"; stationName: "Bethel, AK" }
         ListElement { stationCode: "PAPD"; stationName: "Fairbanks, AK" }
         ListElement { stationCode: "PHKM"; stationName: "Kamuela, HI" }
@@ -154,7 +159,7 @@ KCM.SimpleKCM {
         ListElement { stationCode: "PACG"; stationName: "Sitka, AK" }
         ListElement { stationCode: "PHKI"; stationName: "South Kauai, HI" }
         ListElement { stationCode: "PHWA"; stationName: "South Shore, HI" }
-        ListElement { stationCode: ""; stationName: i18n("Other Sites"); active: false }
+        ListElement { stationCode: ""; stationName: "Other Sites"; active: false }
         ListElement { stationCode: "KFDR"; stationName: "Altus AFB, OK" }
         ListElement { stationCode: "PGUA"; stationName: "Guam" }
         ListElement { stationCode: "KBBX"; stationName: "Beale AFB, CA" }
@@ -184,28 +189,31 @@ KCM.SimpleKCM {
             for (var i = 0; i < radarStationsModel.count; ++i) {
                 var s = radarStationsModel.get(i);
                 var active = (s.active !== false)
-                var display = s.stationCode ? s.stationCode + " - " + s.stationName : s.stationName
+                var translatedName = i18n(s.stationName)
+                var display = s.stationCode ? s.stationCode + " - " + translatedName : translatedName
                 append({ code: s.stationCode, name: s.stationName, display: display, active: active })
             }
         }
     }
 
-    Kirigami.FormLayout {
-        QQC2.ComboBox {
+    QQC2.ComboBox {
             id: radarStationCombo
             Kirigami.FormData.label: i18n("Radar Station:")
             model: displayModel
             textRole: "display"
             valueRole: "code"
             delegate: QQC2.ItemDelegate {
-                width: parent.width
-                text: model.display
-                enabled: model.active
+                required property string display
+                required property bool active
+                width: radarStationCombo.width
+                text: display
+                enabled: active
             }
 
 
-    onActivated: {
+            onActivated: {
                 if (displayModel.get(currentIndex).active) {
+                    cfg_radarStation = currentValue
                     gifUrlField.text = "https://radar.weather.gov/ridge/standard/" + currentValue + "_loop.gif"
                 }
             }
@@ -223,6 +231,8 @@ KCM.SimpleKCM {
                     for (var j = 0; j < displayModel.count; ++j) {
                         if (displayModel.get(j).active) {
                             currentIndex = j
+                            cfg_radarStation = displayModel.get(j).code
+                            gifUrlField.text = "https://radar.weather.gov/ridge/standard/" + cfg_radarStation + "_loop.gif"
                             break
                         }
                     }
@@ -230,18 +240,17 @@ KCM.SimpleKCM {
             }
         }
 
-        QQC2.TextField {
-            id: gifUrlField
-            Kirigami.FormData.label: i18n("Custom GIF URL:")
-            placeholderText: i18n("Or enter custom URL here")
-        }
+    QQC2.TextField {
+        id: gifUrlField
+        Kirigami.FormData.label: i18n("Custom GIF URL:")
+        placeholderText: i18n("Or enter custom URL here")
+    }
 
-        QQC2.SpinBox {
-            id: refreshIntervalSpinBox
-            Kirigami.FormData.label: i18n("Refresh interval (minutes):")
-            from: 1
-            to: 1440
-            stepSize: 1
-        }
+    QQC2.SpinBox {
+        id: refreshIntervalSpinBox
+        Kirigami.FormData.label: i18n("Refresh interval (minutes):")
+        from: 1
+        to: 1440
+        stepSize: 1
     }
 }


### PR DESCRIPTION
## Summary
- expose `Kirigami.FormLayout` directly and declare a `title` property expected by the KConfig loader
- rework radar station ComboBox delegate to bind required role properties and only disable inactive entries

## Testing
- `/usr/lib/qt6/bin/qmllint contents/ui/configGeneral.qml` *(module import warnings)*
- `plasmoidviewer -a .` *(command not found: plasmoidviewer)*

------
https://chatgpt.com/codex/tasks/task_e_6897bb78ffb4832a81c1d1789eab3eaf